### PR TITLE
TST: hide pcaspy import

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -3,7 +3,7 @@
 #
 # This allows running the matplotlib tests from the command line: e.g.
 #
-#   $ python tests.py -v -d
+#   $ python run_tests.py -v -d
 #
 # The arguments are identical to the arguments accepted by nosetests.
 #
@@ -13,51 +13,55 @@ import os
 import signal
 import nose
 from bluesky.testing.noseclasses import KnownFailure
-from multiprocessing import Process
-from pcaspy import Driver, SimpleServer
 
 plugins = [KnownFailure]
 env = {"NOSE_WITH_COVERAGE": 1,
        'NOSE_COVER_PACKAGE': ['bluesky'],
        'NOSE_COVER_HTML': 1}
 
+try:
+    from pcaspy import Driver, SimpleServer
+    from multiprocessing import Process
 
-def to_subproc():
+    def to_subproc():
 
-    prefix = 'BSTEST:'
-    pvdb = {
-        'VAL': {
-            'prec': 3,
-        },
-    }
+        prefix = 'BSTEST:'
+        pvdb = {
+            'VAL': {
+                'prec': 3,
+            },
+        }
 
-    class myDriver(Driver):
-        def __init__(self):
-            super(myDriver, self).__init__()
+        class myDriver(Driver):
+            def __init__(self):
+                super(myDriver, self).__init__()
 
-    if __name__ == '__main__':
-        server = SimpleServer()
-        server.createPV(prefix, pvdb)
-        driver = myDriver()
+        if __name__ == '__main__':
+            server = SimpleServer()
+            server.createPV(prefix, pvdb)
+            driver = myDriver()
 
-        # process CA transactions
-        while True:
-            try:
-                server.process(0.1)
-            except KeyboardInterrupt:
-                break
+            # process CA transactions
+            while True:
+                try:
+                    server.process(0.1)
+                except KeyboardInterrupt:
+                    break
 
-p = Process(target=to_subproc)
+    p = Process(target=to_subproc)
+except ImportError:
+    p = None
 
 
 def run():
-    p.start()
-    print(p)
+    if p is not None:
+        p.start()
     try:
         nose.main(addplugins=[x() for x in plugins], env=env)
     finally:
-        os.kill(p.pid, signal.SIGINT)
-        p.join()
+        if p is not None:
+            os.kill(p.pid, signal.SIGINT)
+            p.join()
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
If epics base is installed and pcaspy is not may cause some tests to
lag/fail due to the pv not being found.
