### PR TITLE
Adding Grid and Trajectory callbacks and a grid_factory callback factory

### DIFF
--- a/bluesky/callbacks/callback_factories.py
+++ b/bluesky/callbacks/callback_factories.py
@@ -1,0 +1,142 @@
+from .mpl_plotting import Grid, Trajectory
+import numpy as np
+
+
+def find_figure(start_doc):
+    '''Determines where the figure should be plotted and returns the figure and
+    axes references.
+    This section checks to see if a current figure exists that the plots can be
+    added too, and if not creates the figure to be plotted on. It is designed
+    to be used in all of the plotting related callback_factories.
+
+    Parameters
+    ----------
+    start_doc : dict
+        the start document issued by the `Run_Engine` when starting a
+    new 'run'.
+
+    Returns
+    -------
+    fig : matplotlib fig reference
+        the reference to the figure we should use to plot.
+    axes : list
+        list of matplotlib axes references.
+    '''
+    # I am proposing placing here all of the mechanisms associated with
+    # checking if we can use an existing figure, how many subplots should be
+    # used and how to arragne them. I prefer this as otherwise there would be
+    # a lot of similar code being employed in each of the figure based
+    # callback_factories. In addition most of this will probably end up living
+    # on the databrowser what do people think?
+
+
+def hinted_fields(descriptor):
+    # Figure out which columns to put in the table and/or to plot.
+    obj_names = list(descriptor['object_keys'])
+    # We will see if these objects hint at whether
+    # a subset of their data keys ('fields') are interesting. If they
+    # did, we'll use those. If these didn't, we know that the RunEngine
+    # *always* records their complete list of fields, so we can use
+    # them all unselectively.
+    columns = []
+    for obj_name in obj_names:
+        try:
+            fields = descriptor.get('hints', {}).get(obj_name, {})['fields']
+        except KeyError:
+            fields = descriptor['object_keys'][obj_name]
+        columns.extend(fields)
+    return columns
+
+
+def grid_factory(start_doc):
+    '''
+    This is a callback factory for 'grid' or 'image' plots. It takes in a
+    start_doc and returns a list of callbacks that have been initialized based
+    on its contents.
+    '''
+    hints = start_doc.get('hints', {})
+    callbacks = []
+
+    # The next line is supposed to take care of where to plot, it can get that
+    # info from anywhere (like the new proposed data-browser) I am expecting
+    # the length of axes to match the number of self.I_names below.
+    fig, axes = find_figure(start_doc)
+
+    # below are some preliminary values required to generate the required
+    # parameters.
+    all_dim_names = [field
+                     for fields, stream_name in hints['dimension']
+                     for field in fields]  # find all dimension field names.
+
+    # define some required parameters for setting up the grid plot.
+    # NOTE: THIS NEEDS WORK, in order to allow for plotting of non-grid type
+    # scans the following parameters need to be passed down to here from the RE
+    # This is the minimum information required to create the grid plot.
+    dim_names = [fields[0]
+                 for fields, stream_name in hints['dimensions']]
+    I_names = [c for c in hinted_fields(start_doc)
+               if c not in all_dim_names]
+    extent = start_doc['extents']
+    shape = start_doc['shape']
+    origin = 'lower'
+
+    # This section adjusts extents so that the values are centered on the grid
+    # pixels
+    data_range = np.array([float(np.diff(e)) for e in extent])
+    y_step, x_step = data_range / [max(1, s - 1) for s in shape]
+    adjusted_extent = [extent[1][0] - x_step / 2,
+                       extent[1][1] + x_step / 2,
+                       extent[0][0] - y_step / 2,
+                       extent[0][1] + y_step / 2]
+
+    # This section is where the scan path is defined, if the x_trajectory and
+    # y_trajectory are 'None' it is not overlayed.
+    # NOTE: we need to decide how to pass this info down to here.
+    x_trajectory = None  # This should be able to take in the path info here.
+    y_trajectory = None  # This should be able to take in the path info here.
+
+    for I_name, ax in zip(I_names, axes):
+
+        # This section defines the function for the grid callback
+        def func(self, bulk_event):
+            '''This functions takes in a bulk event and returns x_coords,
+            y_coords, I_vals lists.
+            '''
+            # start by working out the scaling between grid pixels and axes
+            # units
+            data_range = np.array([float(np.diff(e)) for e in self.extent])
+            y_step, x_step = data_range / [max(1, s - 1) for s in self.shape]
+            x_min = self.extent[0]
+            y_min = self.extent[2]
+            # define the lists of relevant data from the bulk_event
+            x_vals = bulk_event['data'][dim_names[1]]
+            y_vals = bulk_event['data'][dim_names[0]]
+            I_vals = bulk_event['data'][I_name]
+            x_coords = []
+            y_coords = []
+
+            for x_val, y_val in zip(x_vals, y_vals):
+                x_coords.append((x_val-x_min)/x_step)
+                y_coords.append((y_val-y_min)/y_step)
+            return x_coords, y_coords, I_vals  # lists to be returned
+
+        grid_callback = Grid(start_doc, func, shape, ax=ax,
+                             extent=adjusted_extent, origin=origin)
+        callbacks.append(grid_callback)
+
+        # This section defines the callback for the overlayed path.
+        def trajectory_func(self, bulk_event):
+            '''This functions takes in a bulk event and returns x_vals, y_vals
+            lists.
+            '''
+            x_vals = bulk_event['data'][dim_names[1]]
+            y_vals = bulk_event['data'][dim_names[0]]
+            return x_vals, y_vals
+
+        if x_trajectory is not None:
+            trajectory_callback = Trajectory(start_doc, trajectory_func,
+                                             x_trajectory, y_trajectory, ax=ax)
+
+            callbacks.append(trajectory_callback)
+
+    return callbacks

--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -342,6 +342,125 @@ class LiveMesh(LiveScatter):
         super().__init__(*args, **kwargs)
 
 
+class Grid(CallbackBase):
+    '''Draw a matplotlib AxesImage artist and update it for each event.
+    The purposes of this callback is to create (on initialization) of a
+    matplotlib grid image and then update it with new data for every `event`.
+    NOTE: Some important parameters are fed in through **kwargs like `extent`
+    which defines the axes min and max and `origin` which defines if the grid
+    co-ordinates start in the bottom left or top left of the plot. For more
+    info see https://matplotlib.org/tutorials/intermediate/imshow_extent.html
+    or https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.imshow.html#matplotlib.axes.Axes.imshow
+
+    Parameters
+    ----------
+    start_doc: dict
+        not used; accepted and dicarded to satisfy callback_factory API.
+    func : callable
+        This must accept a BulkEvent and return three lists of floats (x
+        grid co-ordinates, y grid co-ordinates and grid position intensity
+        values). The three lists must contain an equal number of items, but
+        that number is arbitrary. That is, a given document may add one new
+        point, no new points or multiple new points to the plot.
+    shape : tuple
+        The (row, col) shape of the grid.
+    single_func : callback, optional
+        This parameter is available as a perfomrance operation. For most uses,
+        ``func`` is sufficient. This is like ``func``, but it gets an Event
+        instead of a BulkEvent. If ``None`` is given, Events are up-cast into
+        BulkEvents and handed to ``func``.
+    ax : matplotlib Axes, optional.
+        if ``None``, a new Figure and Axes are created.
+    **kwargs
+        Passed through to :meth:`Axes.imshow` to style the AxesImage object.
+    '''
+
+    def __init__(self, start_doc, func, shape, *, single_func=None,
+                 ax=None, **kwargs):
+        self.func = func
+        self.shape = shape
+        self.single_func = single_func
+        if ax is None:
+            _, ax = plt.subplots()
+        self.ax = ax
+        self.grid_data = np.full(self.shape, np.nan)
+        self.image, = ax.imshow(self.grid_data, **kwargs)
+
+    def bulk_events(self, doc):
+        '''
+        Takes in a bulk_events document and updates grid_data with the values
+        returned from self.func(doc)
+
+        Parameters
+        ----------
+        doc : dict
+            The bulk event dictionary that contains the 'data' and 'timestamps'
+            associated with the bulk event.
+
+        Returns
+        -------
+        x_coords, y_coords, I_vals : Lists
+            These are lists of x co-ordinate, y co-ordinate and intensity
+            values arising from the bulk event.
+        '''
+        x_coords, y_coords, I_vals = self.func(doc)
+        self._update(x_coords, y_coords, I_vals)
+
+    def event(self, doc):
+        '''
+        Takes in a event documents and updates grid_data with the values
+        returned from self.single_func(doc) or, if it is `None`, self.func(doc)
+
+        Parameters
+        ----------
+        doc : dict
+            The bulk event dictionary that contains the 'data' and 'timestamps'
+            associated with the event.
+
+        Returns
+        -------
+        x_coords, y_coords, I_vals : Lists
+            These are lists of x co-ordinate, y co-ordinate and intensity
+            values arising from the event.
+        '''
+
+        if self.single_func is not None:
+            x_coords, y_coords, I_vals = self.single_func(doc)
+        else:
+            bulk_doc = event2bulk_event(doc)
+            x_coords, y_coords, Ivals = self.func(bulk_doc)
+
+        self._update(x_coords, y_coords, I_vals)
+
+    def _update(self, x_coords, y_coords, I_vals):
+        '''
+        Updates self.grid_data with the values from the lists x_coords,
+        y_coords, I_vals.
+
+        Parameters
+        ----------
+        x_coords, y_coords, I_vals : Lists
+            These are lists of x co-ordinate, y co-ordinate and intensity
+            values arising from the event. The length of all three lists must
+            be the same.
+        '''
+
+        if not len(x_coords) == len(y_coords) == len(I_vals):
+            raise ValueError("User function is expected to provide the same "
+                             "number of x, y and I points. Got {0} x points, "
+                             "{1} y points and {2} I values."
+                             "".format(len(x_coords), len(y_coords),
+                                       len(I_vals)))
+
+        if not x_coords:
+            # No new data, Short-circuit.
+            return
+
+        # Update grid_data and the plot.
+        self.grid_data[x_coords, y_coords] = I_vals
+        self.image.set_array(self.grid_data)
+
+
 class LiveGrid(CallbackBase):
     """Plot gridded 2D data in a "heat map".
 
@@ -608,3 +727,158 @@ def plot_peak_stats(peak_stats, ax=None):
     legend = ax.legend(loc='best')
     arts.update({'points': points, 'vlines': vlines, 'legend': legend})
     return arts
+
+
+class Trajectory(CallbackBase):
+    '''Draw a matplotlib Line2D artist and update it for each event.
+    The purposes of this callback is to create (on initialization) a
+    matplotlib plot indicating the trajectory that a scan will take. During
+    the scan it should also indicate when a point has been taken by removing
+    the point from the trajectory. A second Line2D artist is also included that
+    indicates the actual points that the trajectory took and then update it
+    with new data for every `event`.
+
+    Parameters
+    ----------
+    start_doc: dict
+        not used; accepted and dicarded to satisfy callback_factory API.
+    func : callable
+        This must accept a BulkEvent and return two lists of floats (x
+        values and y values). The two lists must contain an equal number of
+        items, but that number is arbitrary. That is, a given document may add
+        one new point, no new points or multiple new points to the 'completed'
+        plot and remove 0, 1 or more points from the 'future' path.
+    x_trajectory, y_trajectory : Lists
+        Two lists ( `'x_vals'` and `'y_vals'`) which are a list of succesive
+        x_vals or y_vals indicating the trajectory to be taken. The length of
+        the two lists should be identical.
+    single_func : callback, optional
+        This parameter is available as a perfomrance operation. For most uses,
+        ``func`` is sufficient. This is like ``func``, but it gets an Event
+        instead of a BulkEvent. If ``None`` is given, Events are up-cast into
+        BulkEvents and handed to ``func``.
+    ax : matplotlib Axes, optional.
+        if ``None``, a new Figure and Axes are created.
+    **kwargs
+        Passed through to :meth:`Axes.imshow` to style the AxesImage object.
+    '''
+
+    def __init__(self, start_doc, func, x_trajectory, y_trajectory, *,
+                 single_func=None, ax=None, **kwargs):
+        self.func = func
+        self.x_trajectory = x_trajectory
+        self.y_trajectory = y_trajectory
+        self.single_func = single_func
+        if ax is None:
+            _, ax = plt.subplots()
+        self.ax = ax
+        self.x_past = []
+        self.y_past = []
+        self.trajectory = self.ax.plot(self.x_trajectory, self.y_trajectory,
+                                       **kwargs)
+        self.past = self.ax.plot(self.x_past, self.y_past, **kwargs)
+
+    def bulk_events(self, doc):
+        '''Takes in a bulk_events document and updates x_past and y_past with
+        the values returned from self.func(doc).
+
+        Parameters
+        ----------
+        doc : dict
+            The bulk event dictionary that contains the 'data' and 'timestamps'
+            associated with the bulk event.
+
+        Returns
+        -------
+        x_vals, y_vals : Lists
+            These are lists of x values and y values arising from the bulk
+            event.
+        '''
+
+        x_vals, y_vals = self.func(doc)
+        self._update(x_vals, y_vals)
+
+    def event(self, doc):
+        '''
+        Takes in a event documents and returns the values returned from
+        self.single_func(doc) or, if it is `None`, self.func(doc).
+
+        Parameters
+        ----------
+        doc : dict
+            The bulk event dictionary that contains the 'data' and 'timestamps'
+            associated with the event.
+
+        Returns
+        -------
+        x_vals, y_vals : Lists
+            These are lists of x values and y values arising
+            from the event.
+        '''
+
+        if self.single_func is not None:
+            x_vals, y_vals = self.single_func(doc)
+        else:
+            bulk_doc = event2bulk_event(doc)
+            x_vals, y_vals = self.func(bulk_doc)
+        self._update(x_vals, y_vals)
+
+    def _update(self, x_vals, y_vals):
+        '''
+        Updates self.x_past and self.y_past with the values from the lists
+        x_coords, y_coords.
+
+        Parameters
+        ----------
+        x_vals, y_vals : Lists
+            These are lists of x co-ordinate and y co-ordinate values arising
+            from the event. The length of all three lists must be the same.
+        '''
+
+        if not len(x_vals) == len(y_vals):
+            raise ValueError("User function is expected to provide the same "
+                             "number of x and y points. Got {0} x points "
+                             "and {1} y points."
+                             "".format(len(x_vals), len(y_vals)))
+
+        if not x_vals:
+            # No new data, Short-circuit.
+            return
+
+        # Update grid_data and the plot.
+        for x_val, y_val in zip(x_vals, y_vals):
+            # add the new values to the past lists
+            self.x_past.extend(x_val)
+            self.y_past.extend(y_val)
+            # remove the first item from the path lists
+            del self.x_path.pop[0]
+            del self.y_path.pop[0]
+
+        self.path.set_data(self.x_path, self.y_path)
+        self.past.set_data(self.x_past, self.y_past)
+
+
+def event2bulk_event(doc):
+    '''Make a BulkEvent from this Event.
+
+    Parameters
+    ----------
+    doc : dict
+        The event dictionary that contains the 'data' and 'timestamps'
+        associated with the bulk event.
+
+    Returns
+    -------
+    bulk_event : dict
+        The bulk event dictionary that contains the 'data' and 'timestamp'
+        associated with the event.
+    '''
+
+    bulk_event = doc.copy()
+    bulk_event['data'] = {k: np.expand_dims(v, 0)
+                          for k, v in doc['data'].items()}
+
+    bulk_event['timestamps'] = {k: np.expand_dims(v, 0)
+                                for k, v in doc['timestamps'].items()}
+
+    return bulk_event


### PR DESCRIPTION
WORK IN PROGRESS, REQUIRES #1076 BEFORE IT CAN BE TESTED/ USED.
This PR will add a new `Grid` callback, a new `grid_factory` callback factory and potentially a new `path` callback. 

## Description
This will add a replacement to LiveGrid, using the new callback API being added in #1076 and incorporating the changes requested to LiveGrid as detailed in #1095.

## Motivation and Context
It primarily creates a new grid plot that works with the new callbacks mechanism found in #1076. In addition it adds several features requested across the issues #1095, #1039 , #1003, #1001 and #1061. These include: 

- allowing for arbitrary paths through the grid space.
    - This is done through the new function part of the callbacks that allow for more flexibility in the conversion between the data in the event doc and where that is included on the Grid. 
- adding greater flexibility to modify how images are plotted.
    - This is done via the new callback factories and the grid callback API, which allow for any matplotlib kwarg to be passed through to grid
- including the ability to swap axes directions, relative/absolute units and other plotting paths
    - This is done through the new functions for converting between the information in the event docs and where on the grid the data is to be placed.

## How Has This Been Tested?
This has yet to be tested, once PR #1076 is complete then it can be tested and it shouldn't be merged prior to that.